### PR TITLE
Make Shader Minifier twice as fast

### DIFF
--- a/Checker/main.fs
+++ b/Checker/main.fs
@@ -1,5 +1,6 @@
 ﻿open OpenTK.Graphics.OpenGL
 open System
+open System.Diagnostics
 open System.IO
 
 let initOpenTK () =
@@ -25,9 +26,7 @@ let doMinify content =
 
 let check (file: string) =
     try
-        let content =
-            use file = new StreamReader(file)
-            file.ReadToEnd()
+        let content = System.IO.File.ReadAllText file
         if not (testCompile content) then
             printfn "Invalid input file '%s'" file
             false
@@ -44,19 +43,29 @@ let check (file: string) =
         printfn "%A" e
         false
 
+let performanceCheck files =
+    printfn "Running performance tests..."
+    let contents = files |> Array.map System.IO.File.ReadAllText
+    let stopwatch = Stopwatch.StartNew()
+    for str in contents do
+        doMinify str |> ignore
+    let time = stopwatch.Elapsed
+    printfn "%i files minified in %f seconds." files.Length time.TotalSeconds
+
 [<EntryPoint>]
 let main argv =
     initOpenTK()
     let mutable failures = 0
-    let inputs = Directory.GetFiles("tests/unit", "*.frag")
-    for f in inputs do
+    let unitTests = Directory.GetFiles("tests/unit", "*.frag")
+    let realTests = Directory.GetFiles("tests/real", "*.frag");
+    for f in unitTests do
         if not (check f) then
             failures <- failures + 1
+    performanceCheck (Seq.concat [realTests; unitTests] |> Seq.toArray)
     if failures = 0 then
         printfn "All good."
-        // System.Console.ReadLine() |> ignore
-        0
     else
         printfn "%d failures." failures
-        // System.Console.ReadLine() |> ignore
-        1
+    
+    System.Console.ReadLine() |> ignore
+    if failures = 0 then 0 else 1

--- a/src/renamer.fs
+++ b/src/renamer.fs
@@ -33,8 +33,9 @@ let computeContextTable code =
     //let chars, n = Seq.maxBy snd [for pair in contextTable -> pair.Key, pair.Value]
     //printfn "max occ: %A -> %d" chars n
 
+// /!\ This function is a performance bottleneck.
 let chooseIdent ident candidates =
-    let allChars = [char 0 .. char 255]
+    let allChars = [char 32 .. char 127] // printable chars
     let prevs = allChars |> Seq.choose (fun c ->
         match contextTable.TryFind (c, ident) with
         | Some occ -> Some (c, occ)


### PR DESCRIPTION
when the contextual renaming is enabled (which is the default)