### PR TITLE
Printer: avoid modifying the global options object

### DIFF
--- a/src/main.fs
+++ b/src/main.fs
@@ -7,7 +7,7 @@ open Options.Globals
 
 // Compute table of variables names, based on frequency
 let computeFrequencyIdentTable li =
-    let str = Printer.quickPrint li
+    let str = Printer.printText li
 
     let charCounts = Seq.countBy id str |> dict
     let count c = let ok, res = charCounts.TryGetValue(c) in if ok then res else 0
@@ -27,7 +27,7 @@ let computeFrequencyIdentTable li =
 
 let printSize code =
     if options.verbose then
-        printfn "Shader size is: %d" (Printer.quickPrint code).Length
+        printfn "Shader size is: %d" (Printer.printText code).Length
 
 let rename codes =
     let codes = Renamer.renameTopLevel codes Renamer.Unambiguous [||]

--- a/src/printer.fs
+++ b/src/printer.fs
@@ -6,6 +6,8 @@ open Options.Globals
 
 module private PrinterImpl =
 
+    let mutable targetOutput = Options.Text
+
     let out a = sprintf a
 
     let precedenceList = [
@@ -233,14 +235,18 @@ module private PrinterImpl =
 
         tl |> List.map f |> String.concat ""
 
-    let quickPrint tl =
-        let out = options.targetOutput
-        options.targetOutput <- Options.Text
-        let str = print tl
-        options.targetOutput <- out
-        str
+let print tl = 
+    PrinterImpl.targetOutput <- options.targetOutput
+    PrinterImpl.print tl
 
-let quickPrint = PrinterImpl.quickPrint
-let print tl = PrinterImpl.print tl
-let exprToS = PrinterImpl.exprToS
-let typeToS = PrinterImpl.typeToS
+let printText tl =
+    PrinterImpl.targetOutput <- Options.Text
+    PrinterImpl.print tl
+   
+let exprToS x =
+    PrinterImpl.targetOutput <- Options.Text
+    PrinterImpl.exprToS x
+
+let typeToS ty =
+    PrinterImpl.targetOutput <- Options.Text
+    PrinterImpl.typeToS ty

--- a/src/renamer.fs
+++ b/src/renamer.fs
@@ -25,7 +25,7 @@ let makeLetterIdent =
         string(chars.[first]) + string(chars.[second])
 
 let computeContextTable code =
-    Printer.quickPrint code |> Seq.pairwise |> Seq.iter (fun (prev, next) ->
+    Printer.printText code |> Seq.pairwise |> Seq.iter (fun (prev, next) ->
         match contextTable.TryFind (prev, next) with
         | Some n -> contextTable.[(prev, next)] <- n + 1
         | None -> contextTable.[(prev, next)] <- 1


### PR DESCRIPTION
This is in preparation for a change in the option parsing.