### PR TITLE
Fix parentheses when the comma operator is in a function call

### DIFF
--- a/tests/unit/function_comma.frag
+++ b/tests/unit/function_comma.frag
@@ -1,0 +1,19 @@
+float min(float a, float b)
+{
+  return a < b ? a : b;
+}
+
+// https://github.com/laurentlb/Shader_Minifier/issues/20
+float foo()
+{
+  float a = 1.2;
+  float b = 2.3;
+  return min((a=1.0,b+a), 0.0);
+}
+
+float bar()
+{
+  float a = 1.2;
+  float b = 2.3;
+  return min(b+=a, (a, b));
+}


### PR DESCRIPTION
In `min((a=1.0,b+a), 0.0)`, Shader Minifier didn't preserve the parentheses.

Fixes #20
Thanks to dabadab