### PR TITLE
Renamer: reorganize Env

### DIFF
--- a/tests/unit/pi.frag
+++ b/tests/unit/pi.frag
@@ -1,3 +1,4 @@
+#version 400
 
 void main() {
     double pi = 3.141592653589793;

--- a/tests/unit/pi.frag.expected
+++ b/tests/unit/pi.frag.expected
@@ -1,1 +1,2 @@
+#version 400
 void main(){double pi=acos(-1.),minus_pi=-acos(-1.),tau=2.*acos(-1.),minus_tau=-(2.*acos(-1.)),half_pi=acos(0.),minus_half_pi=-acos(0.),precise_pi=acos(-1.);}


### PR DESCRIPTION
The goal is to better separate the AST walking from the renaming strategy.
Also add comments