### PR TITLE
Remove dependency on F# Powerpack

### DIFF
--- a/Shader Minifier.fsproj
+++ b/Shader Minifier.fsproj
@@ -72,9 +72,6 @@
     <Reference Include="FParsecCS">
       <HintPath>lib\FParsecCS.dll</HintPath>
     </Reference>
-    <Reference Include="FSharp.PowerPack">
-      <HintPath>lib\FSharp.PowerPack.dll</HintPath>
-    </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Core">


### PR DESCRIPTION
The library has obsolete for many years. It caused compilation problems (a type conflict) when building for release. We used it only for a hashtable.