### PR TITLE
Support switch statements

### DIFF
--- a/src/printer.fs
+++ b/src/printer.fs
@@ -215,6 +215,15 @@ module private PrinterImpl =
             let s = if System.Char.IsLetterOrDigit s.[s.Length - 1] then s + " " else s
             if s <> "" && s.[0] = '#' then out "%s%s" (backslashN()) (escape s)
             else escape s
+        | Switch(e, cl) ->
+            let labelToS = function
+                | Case e -> out "case %s:" (exprToS e)
+                | Default -> out "default:"
+            let caseToS (l, sl) =
+                let stmts = List.map (stmtToS (indent+2)) sl |> String.concat ""
+                out "%s%s%s" (nl (indent+1)) (labelToS l) stmts
+            let body = List.map caseToS cl |> String.concat ""
+            out "%s(%s){%s%s}" "switch" (exprToS e) body (nl indent)
 
     and stmtToS indent i =
         out "%s%s" (nl indent) (stmtToS' indent i)

--- a/src/printer.fs
+++ b/src/printer.fs
@@ -121,9 +121,9 @@ module private PrinterImpl =
 
     let backslashN() =
         match outputFormat with
-        | Options.Text | Options.JS -> "\n"
+        | Options.Text | Options.JS | Options.IndentedText -> "\n"
         | Options.Nasm -> "', 10, '"
-        | _ ->  "\\n"
+        | Options.CHeader | Options.CList ->  "\\n"
 
     // Print HLSL semantics
     let semToS sem =

--- a/src/renamer.fs
+++ b/src/renamer.fs
@@ -311,6 +311,17 @@ module private RenamerImpl =
             env
         | Jump(_, e) -> renOpt e; env
         | Verbatim _ -> env
+        | Switch(e, cl) ->
+            let renLabel = function
+                | Case e -> renExpr env e
+                | Default -> ()
+            let renCase env (l, sl) =
+                renLabel l
+                renList env renStmt sl |> ignore<Env>
+                env
+            renExpr env e
+            renList env renCase cl |> ignore<Env>
+            env
 
     let rec renTopLevelName env = function
         | TLDecl d -> renDecl true env d

--- a/src/rewriter.fs
+++ b/src/rewriter.fs
@@ -204,7 +204,7 @@ let findInlinable block =
                     localDefs.[def.name.Name] <- (def.name, deps.Count > 0)
         | Expr e
         | Jump (_, Some e) -> localExpr <- e :: localExpr
-        | Verbatim _ | Jump (_, None) | Block _ | If _| ForE _ | ForD _ | While _ | DoWhile _ -> ()
+        | Verbatim _ | Jump (_, None) | Block _ | If _| ForE _ | ForD _ | While _ | DoWhile _ | Switch _ -> ()
 
     let localReferences = collectReferences (List.map Expr localExpr)
     let allReferences = collectReferences block

--- a/tests/commands.txt
+++ b/tests/commands.txt
@@ -39,6 +39,7 @@
 -o tests/unit/function_overload.expected tests/unit/function_overload.frag
 -o tests/unit/externals.expected tests/unit/externals.frag
 -o tests/unit/macros.expected --no-inlining tests/unit/macros.frag
+--format indented -o tests/unit/switch.expected tests/unit/switch.frag
 
 # Optimization tests
 

--- a/tests/unit/switch.expected
+++ b/tests/unit/switch.expected
@@ -1,0 +1,45 @@
+void h()
+{
+  switch(42){
+    case 42:
+      break;
+  }
+}
+
+#define GOOD 42
+
+void i()
+{
+  switch(42){
+    case GOOD:
+      break;
+  }
+}
+void h(in int i)
+{
+  switch(i){
+    case 0:
+      break;
+  }
+}
+void i(in int i)
+{
+  switch(i+42){
+    case 0:
+      break;
+  }
+}
+float G()
+{
+  switch(42){
+    case 42:
+      float i=4.2;
+      float k=2.4;
+      return i+k;
+    case 43:
+      float i=4.3;
+      return i+3.4;
+    default:
+      return 0.;
+  }
+}

--- a/tests/unit/switch.frag
+++ b/tests/unit/switch.frag
@@ -1,0 +1,42 @@
+void switchConst() {
+  switch (42) {
+    case 42:
+      break;
+  }
+}
+
+#define GOOD 42
+void switchDefine() {
+  switch (42) {
+    case GOOD:
+      break;
+  }
+}
+
+void switchArg(in int someArg) {
+  switch (someArg) {
+    case 0:
+      break;
+  }
+}
+
+void switchExpr(in int someArg) {
+  switch (someArg + 42) {
+    case 0:
+      break;
+  }
+}
+
+float switchMultiple() {
+  switch (42) {
+    case 42:
+      float someVar = 4.2;
+      float otherVar = 2.4;
+      return someVar + otherVar;
+    case 43:
+      float someVar = 4.3;
+      return someVar + 3.4;
+    default:
+      return 0.0;
+  }
+}


### PR DESCRIPTION
See commit messages for details. Also incidentally fixes a bug around IndentedText to make my manual testing a bit less annoying. (I also added a test case which incidentally relies on this fix, though that can be easily changed if problematic.)

I do not have a Windows build machine handy, so this was tested entirely on Linux. I was able to confirm that `Checker --skip-glsl-compile` works, but I didn't want to fight to get OpenTK to work. Apologies in advance if I've done anything silly!

While I've done a lot of work with OCaml in the past, this is the first time I've touched FSharp -- once again, apologies in advance if I've done anything silly!