### PR TITLE
Iterate inlining and simplification until we can do no more

### DIFF
--- a/tests/unit/inline.expected
+++ b/tests/unit/inline.expected
@@ -19,10 +19,13 @@ int arithmetic2()
 }
 int unusedVars()
 {
-  int d=30;
-  return d;
+  return 30;
 }
 int unusedVars2()
 {
   return 18;
+}
+int multiPass()
+{
+  return 3;
 }

--- a/tests/unit/inline.frag
+++ b/tests/unit/inline.frag
@@ -45,3 +45,11 @@ int unusedVars2() {
   int var7 = 7, var8 = 8, var9 = 9, var10 = 10, var11 = 11, var12 = 12;
   return var1 + var5 + var12;
 }
+
+int multiPass()
+{
+  int one = 1;
+  int two = one * 2;
+  int three = two + 1;
+  return three;
+}

--- a/tests/unit/inline.no.expected
+++ b/tests/unit/inline.no.expected
@@ -27,3 +27,8 @@ int unusedVars2()
   int var1=1,var2=2,var3=3,var4=4,var5=5,var6=6,var7=7,var8=8,var9=9,var10=10,var11=11,var12=12;
   return var1+var5+var12;
 }
+int multiPass()
+{
+  int one=1,two=one*2,three=two+1;
+  return three;
+}


### PR DESCRIPTION
Inlining can open up new opportunities for simplification. The rewriter
tries to take advantage of this by doing two passes, but there can be
chains of inlinable variables which can require an arbitrary number of
passes. Instead, we can track whether or not we've inlined a variable
this pass, and continue with further passes until we haven't found such
a variable.