### PR TITLE
Fix renamer generating duplicate declarations in switch statements

### DIFF
--- a/src/renamer.fs
+++ b/src/renamer.fs
@@ -317,8 +317,7 @@ module private RenamerImpl =
                 | Default -> ()
             let renCase env (l, sl) =
                 renLabel l
-                renList env renStmt sl |> ignore<Env>
-                env
+                renList env renStmt sl
             renExpr env e
             renList env renCase cl |> ignore<Env>
             env

--- a/tests/unit/switch.expected
+++ b/tests/unit/switch.expected
@@ -37,8 +37,8 @@ float G()
       float k=2.4;
       return i+k;
     case 43:
-      float i=4.3;
-      return i+3.4;
+      float G=4.3;
+      return G+3.4;
     default:
       return 0.;
   }


### PR DESCRIPTION
The entire switch statement is considered one scope, so we need to
thread through the renamer environment so we don't generate duplicate
definitions.

It turns out the test case I added in #132 already hit this -- the
output was not valid GLSL -- but I didn't notice :(