### PR TITLE
Iterate inlining and simplification only when we actually inline

### DIFF
--- a/tests/unit/inline.aggro.expected
+++ b/tests/unit/inline.aggro.expected
@@ -27,3 +27,7 @@ int multiPass()
 {
   return 3;
 }
+float multiPass2()
+{
+  return 9.;
+}

--- a/tests/unit/inline.expected
+++ b/tests/unit/inline.expected
@@ -29,3 +29,7 @@ int multiPass()
 {
   return 3;
 }
+float multiPass2()
+{
+  return 9.;
+}

--- a/tests/unit/inline.frag
+++ b/tests/unit/inline.frag
@@ -53,3 +53,9 @@ int multiPass()
   int three = two + 1;
   return three;
 }
+
+float multiPass2() {
+  float i_a = 4.0;
+  float b = i_a + 5.0;
+  return b;
+}

--- a/tests/unit/inline.no.expected
+++ b/tests/unit/inline.no.expected
@@ -32,3 +32,8 @@ int multiPass()
   int one=1,two=one*2,three=two+1;
   return three;
 }
+float multiPass2()
+{
+  float b=9.;
+  return b;
+}


### PR DESCRIPTION
The logic used in #133 for when to iterate isn't quite right: it runs
another pass when it detects an inlinable variable, not when it actually
inlines. This means we sometimes run an extra pass (i.e., after removing
an unused variable, we don't need to run another pass) and sometimes run
too few passes (i.e., when inlining a variable we didn't "find"
ourselves, such as an `i_blah` variable).

Instead, we can use a very similiar technique but detecting when we
actually do the inlining, not the finding.