### PR TITLE
Allow inlining one-line functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,8 +237,8 @@ This is enabled with `--aggressive-inlining`.
 
 ### Explicit inlining
 
-Shader Minifier will always inline variables that starts with `i_`. Inlining can allow
-the Minifier to simplify the code further.
+Shader Minifier will always inline variables and functions that start with
+`i_`. Inlining can allow the Minifier to simplify the code further.
 
 For example, this input:
 
@@ -263,6 +263,31 @@ int foo(int x,int y)
   return 10*x;
 }
 ```
+
+And this input:
+
+```c
+float i_foo(float f, float g, float x) {
+  return f*x + g*x + f*g;
+}
+
+float bar(float a) {
+  return i_foo(2.0, 3.0, sin(sqrt(a)));
+}
+```
+
+will be simplified into:
+
+```c
+float bar(float a)
+{
+  return 2.*sin(sqrt(a))+3.*sin(sqrt(a))+6.;
+}
+```
+
+Note that the function inlining is very simplistic, only supporting functions
+which consist of a single return statement. (Basically, cases where you would
+use a macro, except this gives the minifier full visibility through it.)
 
 If you want to aggressively reduce the size of your shader, try inlining more
 variables. Inlining can have performance implications though (if the variable

--- a/src/ast.fs
+++ b/src/ast.fs
@@ -131,7 +131,7 @@ type MapEnv = {
     fExpr: MapEnv -> Expr -> Expr
     fStmt: Stmt -> Stmt
     vars: Map<string, Type * DeclElt>
-    fns: Map<string, FunctionType>
+    fns: Map<string, FunctionType * Stmt>
 }
 
 let mapEnv fe fi = {fExpr = fe; fStmt = fi; vars = Map.empty; fns = Map.empty}
@@ -211,7 +211,7 @@ let mapTopLevel env li =
             let env, res = mapDecl env t
             env, TLDecl res
         | Function(fct, body) ->
-            let env = {env with fns = env.fns.Add(fct.fName.Name, fct)}
+            let env = {env with fns = env.fns.Add(fct.fName.Name, (fct, body))}
             env, Function(fct, snd (mapStmt env body))
         | e -> env, e)
     res

--- a/tests/commands.txt
+++ b/tests/commands.txt
@@ -12,12 +12,17 @@
 --hlsl --no-inlining --no-renaming --format c-variables -o tests/unit/geometry.hlsl.expected tests/unit/geometry.hlsl
 --no-renaming --no-inlining --format c-array -o tests/unit/operators.expected tests/unit/operators.frag
 --no-renaming --no-inlining --format c-array -o tests/unit/minus-zero.expected tests/unit/minus-zero.frag
+--no-renaming --format c-array --no-inlining -o tests/unit/float.frag.expected tests/unit/float.frag
+
+# Inlining unit tests
+
 --no-renaming --format indented -o tests/unit/inline.expected tests/unit/inline.frag
 --no-renaming --format indented --aggressive-inlining -o tests/unit/inline.aggro.expected tests/unit/inline.frag
 --no-renaming --format indented --no-inlining -o tests/unit/inline.no.expected tests/unit/inline.frag
 --no-renaming --format indented -o tests/unit/inline-aggro.expected tests/unit/inline-aggro.frag
 --no-renaming --format indented --aggressive-inlining -o tests/unit/inline-aggro.aggro.expected tests/unit/inline-aggro.frag
---no-renaming --format c-array --no-inlining -o tests/unit/float.frag.expected tests/unit/float.frag
+--no-renaming --format indented -o tests/unit/inline-fn.expected tests/unit/inline-fn.frag
+--no-renaming --format indented --aggressive-inlining -o tests/unit/inline-fn.aggro.expected tests/unit/inline-fn.frag
 
 # Partial renaming tests
 

--- a/tests/unit/inline-fn.aggro.expected
+++ b/tests/unit/inline-fn.aggro.expected
@@ -1,0 +1,21 @@
+float a()
+{
+  return vec3(2.,3.,4.).x+vec3(2.,3.,4.).y;
+}
+float b(float g)
+{
+  float x=(g+10.)*vec3(20.,30.,40.).x+vec3(20.,30.,40.).y,y=(g+10.1)*vec3(20.1,30.1,40.1).x+vec3(20.1,30.1,40.1).y;
+  return x+y;
+}
+float c()
+{
+  return 154.;
+}
+float d()
+{
+  return 54.;
+}
+float e()
+{
+  return 84.;
+}

--- a/tests/unit/inline-fn.expected
+++ b/tests/unit/inline-fn.expected
@@ -1,0 +1,22 @@
+float a()
+{
+  return vec3(2.,3.,4.).x+vec3(2.,3.,4.).y;
+}
+float b(float g)
+{
+  float x=(g+10.)*vec3(20.,30.,40.).x+vec3(20.,30.,40.).y,y=(g+10.1)*vec3(20.1,30.1,40.1).x+vec3(20.1,30.1,40.1).y;
+  return x+y;
+}
+float c()
+{
+  return 154.;
+}
+float d()
+{
+  float f=7.,g=f*f+1.;
+  return g+4.;
+}
+float e()
+{
+  return 84.;
+}

--- a/tests/unit/inline-fn.frag
+++ b/tests/unit/inline-fn.frag
@@ -1,0 +1,37 @@
+float i_foo(float f, vec3 g) {
+  return f*g.x + g.y;
+}
+
+float a() {
+  return i_foo(1.0, vec3(2.0, 3.0, 4.0));
+}
+
+float b(float g) {
+  float x = i_foo(g + 10.0, vec3(20.0, 30.0, 40.0));
+  float y = i_foo(g + 10.1, vec3(20.1, 30.1, 40.1));
+  return x + y;
+}
+
+float i_bar(float f, float g) {
+  return f*g + 1.0;
+}
+
+float c() {
+  return i_bar(i_bar(2.0, 3.0), i_bar(4.0, 5.0)) + 6.0;
+}
+
+float d() {
+  float f = i_bar(2.0, 3.0);
+  float g = i_bar(f, f);
+  return g + 4.0;
+}
+
+float i_multipass(float x) {
+  float f = 42.0;
+  float g = 2.0;
+  return f*g*x;
+}
+
+float e() {
+  return i_multipass(1.0);
+}


### PR DESCRIPTION
This implements the simplest possible implementation of inlining
functions. It only supports a function consisting of a single `return`,
when it has been explicitly named as `i_whatever`. Basically, this works
in cases where you might want to use a macro, excpet this gives the
minifier full visibility through it.

The simplicity of this implementation means that it's likely possible to
get into trouble by marking certain functions as to-be-inlined. In
particular, I'm pretty sure the following will break it:
- inlining overloaded functions
- inlining a function into a scope which has a local shadowing a global,
  where the inlined function refers to that global (though this will
  also break a macro)