### PR TITLE
Macro names: preserve the case of the original variable names

### DIFF
--- a/src/formatter.fs
+++ b/src/formatter.fs
@@ -21,9 +21,9 @@ let private printHeader out (shaders: Ast.Shader[]) asAList exportedNames =
     for value: Ast.ExportedName in List.sort exportedNames do
         // let newName = Printer.identTable.[int newName]
         if value.ty = "" then
-            fprintfn out "# define VAR_%s \"%s\"" (value.name.ToUpper()) value.newName
+            fprintfn out "# define VAR_%s \"%s\"" value.name value.newName
         else
-            fprintfn out "# define %s_%s \"%s\"" value.ty (value.name.ToUpper()) value.newName
+            fprintfn out "# define %s_%s \"%s\"" value.ty value.name value.newName
 
     fprintfn out ""
     for shader in shaders do

--- a/tests/commands.txt
+++ b/tests/commands.txt
@@ -34,7 +34,7 @@
 
 # Multifile tests
 
---format indented -o tests/unit/inout.expected tests/unit/inout.frag tests/unit/inout2.frag
+--format c-array -o tests/unit/inout.expected tests/unit/inout.frag tests/unit/inout2.frag
 
 # Tests with full renaming
 

--- a/tests/real/elevated.hlsl.expected
+++ b/tests/real/elevated.hlsl.expected
@@ -3,16 +3,16 @@
  */
 #ifndef ELEVATED_HLSL_EXPECTED_
 # define ELEVATED_HLSL_EXPECTED_
-# define VAR_Q "t"
-# define VAR_T0 "f"
-# define VAR_T1 "m"
-# define VAR_T2 "y"
-# define VAR_V "z"
-# define F_M0 "l"
-# define F_M1 "l"
-# define F_M2 "p"
-# define F_M3 "e"
-# define F_M4 "s"
+# define VAR_q "t"
+# define VAR_t0 "f"
+# define VAR_t1 "m"
+# define VAR_t2 "y"
+# define VAR_v "z"
+# define F_m0 "l"
+# define F_m1 "l"
+# define F_m2 "p"
+# define F_m3 "e"
+# define F_m4 "s"
 
 const char *elevated_hlsl =
  "sampler f,m,y;"

--- a/tests/real/lunaquatic.frag.expected
+++ b/tests/real/lunaquatic.frag.expected
@@ -3,8 +3,8 @@
  */
 #ifndef LUNAQUATIC_FRAG_EXPECTED_
 # define LUNAQUATIC_FRAG_EXPECTED_
-# define VAR_RESOLUTION "z"
-# define VAR_TIME "m"
+# define VAR_resolution "z"
+# define VAR_time "m"
 
 const char *lunaquatic_frag =
  "#extension GL_EXT_gpu_shader4:enable\n"

--- a/tests/real/oscars_chair.frag.expected
+++ b/tests/real/oscars_chair.frag.expected
@@ -3,7 +3,7 @@
  */
 #ifndef OSCARS_CHAIR_FRAG_EXPECTED_
 # define OSCARS_CHAIR_FRAG_EXPECTED_
-# define VAR_TEX1 "a"
+# define VAR_tex1 "a"
 
 const char *oscars_chair_frag =
  "#version 130\n"

--- a/tests/real/sult.expected
+++ b/tests/real/sult.expected
@@ -3,8 +3,8 @@
  */
 #ifndef SULT_EXPECTED_
 # define SULT_EXPECTED_
-# define VAR_RESOLUTION "m"
-# define VAR_TIME "c"
+# define VAR_resolution "m"
+# define VAR_time "c"
 
 const char *sult_frag =
  "float v=5.,z=.9,y=0.,a=90.,x=0.;"

--- a/tests/real/yx_long_way_from_home.frag.expected
+++ b/tests/real/yx_long_way_from_home.frag.expected
@@ -3,7 +3,7 @@
  */
 #ifndef YX_LONG_WAY_FROM_HOME_FRAG_EXPECTED_
 # define YX_LONG_WAY_FROM_HOME_FRAG_EXPECTED_
-# define VAR_ICHANNEL1 "v"
+# define VAR_iChannel1 "v"
 
 const char *yx_long_way_from_home_frag =
  "#version 130\n"

--- a/tests/unit/externals.expected
+++ b/tests/unit/externals.expected
@@ -3,9 +3,9 @@
  */
 #ifndef EXTERNALS_EXPECTED_
 # define EXTERNALS_EXPECTED_
-# define VAR_E "t"
-# define VAR_I "i"
-# define VAR_N "n"
+# define VAR_e "t"
+# define VAR_i "i"
+# define VAR_n "n"
 
 const char *externals_frag =
  "uniform int i,n,t;"

--- a/tests/unit/inout.expected
+++ b/tests/unit/inout.expected
@@ -1,51 +1,60 @@
+/* File generated with Shader Minifier 1.2
+ * http://www.ctrl-alt-test.fr
+ */
+# define VAR_ambientLight "m"
+# define VAR_diffuseColor "i"
+# define VAR_emissiveColor "a"
+# define VAR_fragmentColor "o"
+# define VAR_mediumDensity "t"
+# define VAR_normal "c"
+# define VAR_specularColor "n"
+# define VAR_texture0 "e"
+# define VAR_viewVec "v"
+
 // tests/unit/inout.frag
-
-#version 330
-
-uniform samplerCube e;
-in vec3 c,v;
-out vec4 o;
-void main()
-{
-  vec3 l=normalize(v),u=normalize(c),f=vec3(.1,.2,.3),x=texture(e,reflect(-l,u)).xyz,p=texture(e,refract(-l,u,1./1.5)).xyz,z=mix(f*p,x,.1);
-  o=vec4(z,1.);
-}
-vec3 r(vec3 d,vec3 l,vec3 s)
-{
-  float C=1.-clamp(dot(l,s),0.,1.);
-  return C*C*C*C*C*(1.-d)+d;
-}
-vec3 r(vec3 l,vec3 y,vec3 u,vec3 f,vec3 d,float w)
-{
-  vec3 s=normalize(l+y);
-  float b=1.+2048.*(1.-w)*(1.-w);
-  vec3 Z=f,Y=vec3(pow(clamp(dot(s,u),0.,1.),b)*(b+4.)/8.),X=r(d,l,s);
-  return mix(Z,Y,X);
-}
+"#version 330\n"
+ "uniform samplerCube e;"
+ "in vec3 c,v;"
+ "out vec4 o;"
+ "void main()"
+ "{"
+   "vec3 l=normalize(v),u=normalize(c),f=vec3(.1,.2,.3),x=texture(e,reflect(-l,u)).xyz,p=texture(e,refract(-l,u,1./1.5)).xyz,z=mix(f*p,x,.1);"
+   "o=vec4(z,1.);"
+ "}"
+ "vec3 r(vec3 d,vec3 l,vec3 s)"
+ "{"
+   "float C=1.-clamp(dot(l,s),0.,1.);"
+   "return C*C*C*C*C*(1.-d)+d;"
+ "}"
+ "vec3 r(vec3 l,vec3 y,vec3 u,vec3 f,vec3 d,float w)"
+ "{"
+   "vec3 s=normalize(l+y);"
+   "float b=1.+2048.*(1.-w)*(1.-w);"
+   "vec3 Z=f,Y=vec3(pow(clamp(dot(s,u),0.,1.),b)*(b+4.)/8.),X=r(d,l,s);"
+   "return mix(Z,Y,X);"
+ "}",
 
 // tests/unit/inout2.frag
-
-#version 330
-
-uniform samplerCube e;
-uniform float t;
-uniform vec3 m,i,a,n;
-in vec3 c,v;
-out vec4 o;
-vec3 r(vec3 d,vec3 l,vec3 s)
-{
-  float C=1.-clamp(dot(l,s),0.,1.);
-  return C*C*C*C*C*(1.-d)+d;
-}
-void main()
-{
-  vec3 f=i,z=a+mix(f*m,m,.5);
-  o=vec4(z,1.);
-}
-vec3 r(vec3 l,vec3 y,vec3 u,vec3 f,vec3 d,float w)
-{
-  vec3 s=normalize(l+y);
-  float b=1.+2048.*(1.-w)*(1.-w);
-  vec3 Z=f,Y=vec3(pow(clamp(dot(s,u),0.,1.),b)*(b+4.)/8.),X=r(d,l,s);
-  return mix(Z,Y,X);
-}
+"#version 330\n"
+ "uniform samplerCube e;"
+ "uniform float t;"
+ "uniform vec3 m,i,a,n;"
+ "in vec3 c,v;"
+ "out vec4 o;"
+ "vec3 r(vec3 d,vec3 l,vec3 s)"
+ "{"
+   "float C=1.-clamp(dot(l,s),0.,1.);"
+   "return C*C*C*C*C*(1.-d)+d;"
+ "}"
+ "void main()"
+ "{"
+   "vec3 f=i,z=a+mix(f*m,m,.5);"
+   "o=vec4(z,1.);"
+ "}"
+ "vec3 r(vec3 l,vec3 y,vec3 u,vec3 f,vec3 d,float w)"
+ "{"
+   "vec3 s=normalize(l+y);"
+   "float b=1.+2048.*(1.-w)*(1.-w);"
+   "vec3 Z=f,Y=vec3(pow(clamp(dot(s,u),0.,1.),b)*(b+4.)/8.),X=r(d,l,s);"
+   "return mix(Z,Y,X);"
+ "}",

--- a/tests/unit/qualifiers.expected
+++ b/tests/unit/qualifiers.expected
@@ -3,7 +3,7 @@
  */
 #ifndef QUALIFIERS_EXPECTED_
 # define QUALIFIERS_EXPECTED_
-# define VAR_FOO "f"
+# define VAR_foo "f"
 
 const char *qualifiers_frag =
  "in vec3 f;"


### PR DESCRIPTION
If there's a uniform "time", we used to generate the macro "VAR_TIME". Instead, we now preserve the case and generate the macro "VAR_time".
Rationale: with the change in case, we might get conflicts in the macro names (e.g. if you had both "t" and "T"). This happens for example when the names were already minified.