### PR TITLE
Cleanup: remove deprecated ref operators

### DIFF
--- a/src/parse.fs
+++ b/src/parse.fs
@@ -233,7 +233,7 @@ module private ParseImpl =
         many (ch ':' >>. simpleExpr)
 
     // eg. "int foo[] = exp, bar = 3"
-    declRef := (
+    declRef.Value <- (
         let bracket = between (ch '[') (ch ']') (opt expr) |>> (fun size -> defaultArg size (Ast.Int (0, "")))
         let init = ch '=' >>. exprNoComma
         let var = pipe4 ident (opt bracket) semantics (opt init) Ast.makeDecl
@@ -321,7 +321,7 @@ module private ParseImpl =
         (key <|> ret) .>> ch ';'
 
     // A statement
-    stmtRef := choice [
+    stmtRef.Value <- choice [
         block
         jump
         forLoop

--- a/src/renamer.fs
+++ b/src/renamer.fs
@@ -120,8 +120,8 @@ module private RenamerImpl =
                                     (* ** Renamer ** *)
 
     let newUniqueId (numberOfUsedIdents: int ref) (env: Env) (id: Ident) =
-        incr numberOfUsedIdents
-        let newName = sprintf "%04d" !numberOfUsedIdents
+        numberOfUsedIdents.Value <- numberOfUsedIdents.Value + 1
+        let newName = sprintf "%04d" numberOfUsedIdents.Value
         env.Rename(id, newName)
 
     // A renaming strategy that considers how a variable is used. It optimizes the frequency of
@@ -167,7 +167,7 @@ module private RenamerImpl =
 
     let export env ty (id: Ident) =
         if not id.IsUniqueId then
-            env.exportedNames := {ty = ty; name = id.OldName; newName = id.Name} :: !env.exportedNames
+            env.exportedNames.Value <- {ty = ty; name = id.OldName; newName = id.Name} :: env.exportedNames.Value
 
     let renFunction env nbArgs (id: Ident) =
         // we're looking for a function name, already used before,
@@ -357,7 +357,7 @@ module private RenamerImpl =
         // Rename local variables.
         for shader in shaders do
             List.iter (renTopLevelBody env) shader.code
-        !env.exportedNames
+        env.exportedNames.Value
 
     let assignUniqueIds shaders =
         let numberOfUsedIdents = ref 0
@@ -382,7 +382,7 @@ module private RenamerImpl =
                 let contextTable = computeContextTable text
                 Env.Create(names, true, optimizeContext contextTable, shadowVariables)
         env <- dontRenameList env options.noRenamingList
-        env.exportedNames := exportedNames
+        env.exportedNames.Value <- exportedNames
         renameAsts shaders env
 
 let rename = RenamerImpl.rename


### PR DESCRIPTION
F# has recently decided to deprecate some operators on the ref type:  `!`, `:=`, `incr` and `decr`

See https://aka.ms/fsharp-refcell-ops