### PR TITLE
Fix dangling else bug

### DIFF
--- a/tests/commands.txt
+++ b/tests/commands.txt
@@ -13,6 +13,7 @@
 --no-renaming --no-inlining --format c-array -o tests/unit/operators.expected tests/unit/operators.frag
 --no-renaming --no-inlining --format c-array -o tests/unit/minus-zero.expected tests/unit/minus-zero.frag
 --no-renaming --format c-array --no-inlining -o tests/unit/float.frag.expected tests/unit/float.frag
+--no-renaming --format indented --no-inlining -o tests/unit/nested_if.frag.expected tests/unit/nested_if.frag
 
 # Inlining unit tests
 

--- a/tests/unit/nested_if.frag
+++ b/tests/unit/nested_if.frag
@@ -36,7 +36,7 @@ int dandling_else(int x) {
       if (x > 0) {
         return 0;
       } else {
-        if (x == 0) return 1; // dandling
+        if (x == 0) return 1; // dangling
       }
   } else {
     return 2;

--- a/tests/unit/nested_if.frag
+++ b/tests/unit/nested_if.frag
@@ -1,0 +1,44 @@
+float getNum(float a) {
+  // else statement, so curly braces are required
+  if (a > 0.0) {
+    if (a > 1.0) return 1.0;
+  }
+  else return 0.0;
+  return a;
+}
+
+int nested(bool x, bool y) {
+  if (x) {
+    // no else statement, so curly braces can be removed
+    if (y) {
+      return 0;
+    }
+  }
+  return 2;
+}
+
+int no_braces1(int x) {
+  if (x < 0) {
+    for (;;)
+      if (x > 0) {
+        return 0;
+      } else {
+        return 1;
+      }
+  } else {
+    return 2;
+  }
+}
+
+int dandling_else(int x) {
+  if (x < 0) {
+    for (;;)
+      if (x > 0) {
+        return 0;
+      } else {
+        if (x == 0) return 1; // dandling
+      }
+  } else {
+    return 2;
+  }
+}

--- a/tests/unit/nested_if.frag
+++ b/tests/unit/nested_if.frag
@@ -30,7 +30,7 @@ int no_braces1(int x) {
   }
 }
 
-int dandling_else(int x) {
+int dangling_else(int x) {
   if (x < 0) {
     for (;;)
       if (x > 0) {

--- a/tests/unit/nested_if.frag.expected
+++ b/tests/unit/nested_if.frag.expected
@@ -27,7 +27,7 @@ int no_braces1(int x)
   else
      return 2;
 }
-int dandling_else(int x)
+int dangling_else(int x)
 {
   if(x<0)
     {

--- a/tests/unit/nested_if.frag.expected
+++ b/tests/unit/nested_if.frag.expected
@@ -1,0 +1,43 @@
+float getNum(float a)
+{
+  if(a>0.)
+    {
+      if(a>1.)
+        return 1.;
+    }
+  else
+     return 0.;
+  return a;
+}
+int nested(bool x,bool y)
+{
+  if(x)
+    if(y)
+      return 0;
+  return 2;
+}
+int no_braces1(int x)
+{
+  if(x<0)
+    for(;;)
+      if(x>0)
+        return 0;
+      else
+         return 1;
+  else
+     return 2;
+}
+int dandling_else(int x)
+{
+  if(x<0)
+    {
+      for(;;)
+        if(x>0)
+          return 0;
+        else
+           if(x==0)
+            return 1;
+    }
+  else
+     return 2;
+}


### PR DESCRIPTION
Detect if the statement inside a `if` might accept a dangling else. This can handle cases like:
     if(a) for(;;) if(b) {} else {}

Fixes https://github.com/laurentlb/Shader_Minifier/issues/143