### PR TITLE
Split the project in two projects: a library and the binary

### DIFF
--- a/Checker/Checker.fsproj
+++ b/Checker/Checker.fsproj
@@ -73,8 +73,8 @@
     <Reference Include="System.ValueTuple" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Shader Minifier.fsproj">
-      <Name>Shader Minifier</Name>
+    <ProjectReference Include="..\Shader Minifier Library.fsproj">
+      <Name>Shader Minifier Library</Name>
       <Project>{059c6af3-1877-4698-be34-bf7eb55d060a}</Project>
       <Private>True</Private>
     </ProjectReference>

--- a/Checker/main.fs
+++ b/Checker/main.fs
@@ -43,7 +43,7 @@ let canBeCompiled content =
             false
 
 let doMinify content =
-    let arr = Main.minify [|"input", content|] |> fst |> Array.map (fun s -> s.code)
+    let arr = ShaderMinifier.minify [|"input", content|] |> fst |> Array.map (fun s -> s.code)
     Printer.printText arr.[0]
 
 let testMinifyAndCompile (file: string) =
@@ -83,7 +83,7 @@ let runCommand argv =
            | _ -> reraise ()
     let result =
         use out = new StringWriter()
-        let shaders, exportedNames = Main.minifyFiles options.filenames
+        let shaders, exportedNames = ShaderMinifier.minifyFiles options.filenames
         Formatter.print out shaders exportedNames options.outputFormat
         out.ToString() |> cleanString
     if result = expected then

--- a/Shader Minifier Library.fsproj
+++ b/Shader Minifier Library.fsproj
@@ -58,7 +58,7 @@
     <Compile Include="src\renamer.fs" />
     <Compile Include="src\rewriter.fs" />
     <Compile Include="src\parse.fs" />
-    <Compile Include="src\main.fs" />
+    <Compile Include="src\api.fs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Argu">

--- a/Shader Minifier Library.fsproj
+++ b/Shader Minifier Library.fsproj
@@ -1,0 +1,85 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{059c6af3-1877-4698-be34-bf7eb55d060a}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>glsl_minifier</RootNamespace>
+    <AssemblyName>shader_minifier_lib</AssemblyName>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <Name>Shader Minifier Library</Name>
+    <TargetFrameworkProfile />
+    <TargetFSharpCoreVersion>6.0.0.0</TargetFSharpCoreVersion>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <Tailcalls>false</Tailcalls>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>5</WarningLevel>
+    <StartArguments>-o "" ../../tests\unit\commas.frag --smoothstep</StartArguments>
+    <OtherFlags>--warnon:1182</OtherFlags>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <Tailcalls>true</Tailcalls>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <StartArguments>-o "" ../../tests\unit\empty_block.frag --smoothstep</StartArguments>
+    <OtherFlags>
+    </OtherFlags>
+  </PropertyGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup>
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
+  <ItemGroup>
+    <Compile Include="src\options.fs" />
+    <Compile Include="src\ast.fs" />
+    <Compile Include="src\printer.fs" />
+    <Compile Include="src\formatter.fs" />
+    <Compile Include="src\renamer.fs" />
+    <Compile Include="src\rewriter.fs" />
+    <Compile Include="src\parse.fs" />
+    <Compile Include="src\main.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Argu">
+      <HintPath>lib\Argu.dll</HintPath>
+    </Reference>
+    <Reference Include="FParsec">
+      <HintPath>lib\FParsec.dll</HintPath>
+    </Reference>
+    <Reference Include="FParsecCS">
+      <HintPath>lib\FParsecCS.dll</HintPath>
+    </Reference>
+    <Reference Include="FSharp.Core">
+      <HintPath>lib\FSharp.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple" />
+  </ItemGroup>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
+	     Other similar extension points exist, see Microsoft.Common.targets.
+	<Target Name="BeforeBuild">
+	</Target>
+	<Target Name="AfterBuild">
+	</Target>
+	-->
+</Project>

--- a/Shader Minifier.fsproj
+++ b/Shader Minifier.fsproj
@@ -5,7 +5,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{059c6af3-1877-4698-be34-bf7eb55d060a}</ProjectGuid>
+    <ProjectGuid>{7a0b4487-c3f6-4753-9c8d-fee09049f52d}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <RootNamespace>glsl_minifier</RootNamespace>
     <AssemblyName>shader_minifier</AssemblyName>
@@ -50,13 +50,6 @@
   </Choose>
   <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
   <ItemGroup>
-    <Compile Include="src\options.fs" />
-    <Compile Include="src\ast.fs" />
-    <Compile Include="src\printer.fs" />
-    <Compile Include="src\formatter.fs" />
-    <Compile Include="src\renamer.fs" />
-    <Compile Include="src\rewriter.fs" />
-    <Compile Include="src\parse.fs" />
     <Compile Include="src\main.fs" />
   </ItemGroup>
   <ItemGroup>
@@ -73,6 +66,13 @@
       <HintPath>lib\FSharp.Core.dll</HintPath>
     </Reference>
     <Reference Include="System.ValueTuple" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="Shader Minifier Library.fsproj">
+      <Name>Shader Minifier Library</Name>
+      <Project>{059c6af3-1877-4698-be34-bf7eb55d060a}</Project>
+      <Private>True</Private>
+    </ProjectReference>
   </ItemGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
 	     Other similar extension points exist, see Microsoft.Common.targets.

--- a/Shader Minifier.sln
+++ b/Shader Minifier.sln
@@ -1,9 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32819.101
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Shader Minifier", "Shader Minifier.fsproj", "{059C6AF3-1877-4698-BE34-BF7EB55D060A}"
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Shader Minifier Library", "Shader Minifier Library.fsproj", "{059C6AF3-1877-4698-BE34-BF7EB55D060A}"
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Checker", "Checker\Checker.fsproj", "{CF735CB3-7698-41DA-9E91-69D0057087CB}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -27,5 +27,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {0FF87597-650A-442F-BCAD-095B520AF893}
 	EndGlobalSection
 EndGlobal

--- a/Shader Minifier.sln
+++ b/Shader Minifier.sln
@@ -10,6 +10,8 @@ Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Checker", "Checker\Checker.
 		{059C6AF3-1877-4698-BE34-BF7EB55D060A} = {059C6AF3-1877-4698-BE34-BF7EB55D060A}
 	EndProjectSection
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Shader Minifier", "Shader Minifier.fsproj", "{7A0B4487-C3F6-4753-9C8D-FEE09049F52D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -24,6 +26,10 @@ Global
 		{CF735CB3-7698-41DA-9E91-69D0057087CB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CF735CB3-7698-41DA-9E91-69D0057087CB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CF735CB3-7698-41DA-9E91-69D0057087CB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7A0B4487-C3F6-4753-9C8D-FEE09049F52D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7A0B4487-C3F6-4753-9C8D-FEE09049F52D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7A0B4487-C3F6-4753-9C8D-FEE09049F52D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7A0B4487-C3F6-4753-9C8D-FEE09049F52D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/api.fs
+++ b/src/api.fs
@@ -1,0 +1,54 @@
+﻿module ShaderMinifier
+
+open System
+open System.IO
+open Microsoft.FSharp.Text
+open Options.Globals
+
+let printSize (shaders: Ast.Shader[]) =
+    if options.verbose then
+        let length = shaders |> Array.map (fun s -> Printer.printText s.code)
+                   |> Array.sumBy (fun s -> s.Length)
+        printfn "Shader size is: %d" length
+
+let readFile file =
+    let stream =
+        if file = "" then new StreamReader(Console.OpenStandardInput())
+        else new StreamReader(file)
+    stream.ReadToEnd()
+
+let minify (files: (string*string)[]) =
+    vprintf "Input file size is: %d\n" (files |> Array.sumBy (fun (_, s) -> s.Length))
+    let shaders = files |> Array.map (fun (f, c) -> Parse.runParser f c)
+    vprintf "File parsed. "; printSize shaders
+
+    for shader in shaders do
+        shader.code <- Rewriter.reorder shader.code
+        shader.code <- Rewriter.simplify shader.code
+    vprintf "Rewrite tricks applied. "; printSize shaders
+
+    if options.noRenaming then
+        shaders, []
+    else
+        let exportedNames = Renamer.rename shaders
+        vprintf "Identifiers renamed. "; printSize shaders
+        shaders, exportedNames
+
+let minifyFiles files =
+    let files = files |> Array.map (fun f ->
+        let content = readFile f
+        let filename = if f = "" then "stdin" else f
+        filename, content)
+    minify files
+
+let run files =
+    use out =
+        if Options.debugMode || options.outputName = "" || options.outputName = "-" then stdout
+        else new StreamWriter(options.outputName) :> TextWriter
+    try
+        let shaders, exportedNames = minifyFiles files
+        Formatter.print out shaders exportedNames options.outputFormat
+        0
+    with exn ->
+        printfn "%s" (exn.ToString())
+        1

--- a/src/main.fs
+++ b/src/main.fs
@@ -1,57 +1,6 @@
 ﻿module Main
 
-open System
-open System.IO
-open Microsoft.FSharp.Text
 open Options.Globals
-
-let printSize (shaders: Ast.Shader[]) =
-    if options.verbose then
-        let length = shaders |> Array.map (fun s -> Printer.printText s.code)
-                   |> Array.sumBy (fun s -> s.Length)
-        printfn "Shader size is: %d" length
-
-let readFile file =
-    let stream =
-        if file = "" then new StreamReader(Console.OpenStandardInput())
-        else new StreamReader(file)
-    stream.ReadToEnd()
-
-let minify (files: (string*string)[]) =
-    vprintf "Input file size is: %d\n" (files |> Array.sumBy (fun (_, s) -> s.Length))
-    let shaders = files |> Array.map (fun (f, c) -> Parse.runParser f c)
-    vprintf "File parsed. "; printSize shaders
-
-    for shader in shaders do
-        shader.code <- Rewriter.reorder shader.code
-        shader.code <- Rewriter.simplify shader.code
-    vprintf "Rewrite tricks applied. "; printSize shaders
-
-    if options.noRenaming then
-        shaders, []
-    else
-        let exportedNames = Renamer.rename shaders
-        vprintf "Identifiers renamed. "; printSize shaders
-        shaders, exportedNames
-
-let minifyFiles files =
-    let files = files |> Array.map (fun f ->
-        let content = readFile f
-        let filename = if f = "" then "stdin" else f
-        filename, content)
-    minify files
-
-let run files =
-    use out =
-        if Options.debugMode || options.outputName = "" || options.outputName = "-" then stdout
-        else new StreamWriter(options.outputName) :> TextWriter
-    try
-        let shaders, exportedNames = minifyFiles files
-        Formatter.print out shaders exportedNames options.outputFormat
-        0
-    with exn ->
-        printfn "%s" (exn.ToString())
-        1
 
 [<EntryPoint>]
 let main argv =
@@ -60,7 +9,7 @@ let main argv =
             if Options.init argv then 
                 if options.verbose then
                     printfn "Shader Minifier %s - https://github.com/laurentlb/Shader_Minifier" Options.version
-                run options.filenames
+                ShaderMinifier.run options.filenames
             else 1
         with
         | :? Argu.ArguParseException as ex ->


### PR DESCRIPTION
This lets us reuse the Shader Minifier library more easily. The first motivation is for the WebAssembly build. Other people might also want to use the library from the .NET tool.

As a side bonus, the Checker can now be used in Release mode (the --standalone flag on the executable was breaking this).