### PR TITLE
Support array types

### DIFF
--- a/src/ast.fs
+++ b/src/ast.fs
@@ -63,6 +63,7 @@ and TypeSpec =
 and Type = {
     name: TypeSpec // e.g. int
     typeQ: string list // e.g. const, uniform
+    arraySizes: Expr list // e.g. [3][5]
 }
 
 and DeclElt = {
@@ -104,7 +105,7 @@ and TopLevel =
     | TLDecl of Decl
     | TypeDecl of TypeSpec // structs
 
-let makeType name tyQ = {Type.name=name; typeQ=tyQ}
+let makeType name tyQ sizes = {Type.name=name; typeQ=tyQ; arraySizes=sizes}
 let makeDecl name size sem init = {name=name; size=size; semantics=sem; init=init}
 let makeFunctionType ty name args sem =
     {retType=ty; fName=name; args=args; semantics=sem}

--- a/src/rewriter.fs
+++ b/src/rewriter.fs
@@ -212,7 +212,7 @@ let private rwTypeSpec = function
     | x -> x // structs
 
 let rwType (ty: Type) =
-    makeType (rwTypeSpec ty.name) (List.map stripSpaces ty.typeQ)
+    makeType (rwTypeSpec ty.name) (List.map stripSpaces ty.typeQ) ty.arraySizes
 
 let rwFType fct =
     // The default for function parameters is "in", we don't need it.

--- a/tests/unit/array.frag
+++ b/tests/unit/array.frag
@@ -8,3 +8,11 @@ float b[size] = float[size](3.4, 4.2, 5.0, 5.2, 1.1);
 float c[] = float[](3.4, 4.2, 5.0, 5.2, 1.1);
 float d[5] = float[](3.4, 4.2, 5.0, 5.2, 1.1);
 float e[] = float[5](3.4, 4.2, 5.0, 5.2, 1.1);
+
+void arrayTypes() {
+	vec4 a[3];
+	vec4[2] b[3];
+	vec4[3] c;
+
+	int code[] = int[1](123);
+}


### PR DESCRIPTION
GLSL supports an alternative array declaration. Both of these are valid:
  int[2] a;
  int a[2];