### PR TITLE
Fix stackoverflow error in simplifyExpr

### DIFF
--- a/src/options.fs
+++ b/src/options.fs
@@ -3,7 +3,7 @@
 open System.IO
 open Argu
 
-let version = "1.3" // Shader Minifier version
+let version = "1.3.1" // Shader Minifier version
 let debugMode = false
 
 type OutputFormat =

--- a/src/options.fs
+++ b/src/options.fs
@@ -3,7 +3,7 @@
 open System.IO
 open Argu
 
-let version = "1.3.1" // Shader Minifier version
+let version = "1.3" // Shader Minifier version
 let debugMode = false
 
 type OutputFormat =

--- a/tests/unit/operators.expected
+++ b/tests/unit/operators.expected
@@ -20,4 +20,8 @@
  "{"
    "int d=b*c*a;"
    "return a-b+1-d+c;"
+ "}"
+ "int other(int a,int b,int c,int d)"
+ "{"
+   "return a*b*(c*d)*(a*b);"
  "}",

--- a/tests/unit/operators.frag
+++ b/tests/unit/operators.frag
@@ -20,3 +20,7 @@ int no_parens2(int a, int b, int c) {
 	int d = a*(b*c);
 	return a - (b - 1) - (d - c);
 }
+
+int other(int a, int b, int c, int d) {
+    return (a*b)*(c*d)*(a*b);
+}


### PR DESCRIPTION
This was caused by trying to reorder multiple arguments back and forth