### PR TITLE
Improve tests & update version to 1.3.1

### DIFF
--- a/Checker/main.fs
+++ b/Checker/main.fs
@@ -5,6 +5,7 @@ open System.Diagnostics
 open System.IO
 
 open Argu
+open System.Text.RegularExpressions
 
 type CliArguments =
     | Update_Golden
@@ -74,8 +75,14 @@ let testPerformance files =
     let time = stopwatch.Elapsed
     printfn "%i files minified in %f seconds." files.Length time.TotalSeconds
 
+// Generated files may contain the Shader Minifier version.
+// Ignore version changes in the tests.
+let versionRegex = new Regex(@"\bShader Minifier \d(\.\d+)+");
+
 let runCommand argv =
-    let cleanString (s: string) = s.Replace("\r\n", "\n").Trim()
+    let cleanString (s: string) =
+        let s = s.Replace("\r\n", "\n").Trim()
+        versionRegex.Replace(s, "")
     Options.init argv
     let expected =
         try File.ReadAllText options.outputName |> cleanString

--- a/src/options.fs
+++ b/src/options.fs
@@ -3,7 +3,7 @@
 open System.IO
 open Argu
 
-let version = "1.3" // Shader Minifier version
+let version = "1.3.1" // Shader Minifier version
 let debugMode = false
 
 type OutputFormat =

--- a/tests/unit/inline-aggro.aggro.expected
+++ b/tests/unit/inline-aggro.aggro.expected
@@ -110,7 +110,7 @@ int noinl11(ivec3 x)
   x[i++]+=1;
   return x[i]+i;
 }
-float noinl12()
+int noinl12()
 {
   int i=10;
   while(--i>0)

--- a/tests/unit/inline-aggro.expected
+++ b/tests/unit/inline-aggro.expected
@@ -118,7 +118,7 @@ int noinl11(ivec3 x)
   x[i++]+=1;
   return x[i]+i;
 }
-float noinl12()
+int noinl12()
 {
   int i=10;
   while(--i>0)

--- a/tests/unit/inline-aggro.frag
+++ b/tests/unit/inline-aggro.frag
@@ -119,7 +119,7 @@ int noinl11(in ivec3 x) {
 	return x[i] + i;
 }
 
-float noinl12() {
+int noinl12() {
 	int i = 10;
 	while (--i > 0) {
 	}


### PR DESCRIPTION
- Tests now ignore the version change (to avoid regenerating a bunch of golden files)
- Fix shader compilation warning (int vs float)