### PR TITLE
Preserve comments inside verbatim blocks

### DIFF
--- a/src/parse.fs
+++ b/src/parse.fs
@@ -27,8 +27,8 @@ module private ParseImpl =
 
     let verbatim = parse {
         do! skipString "//["
-        do! skipComment
-        let! content = manyCharsTill (anyChar .>> skipComment) (pstring "//]")
+        do! many spaces1 |>> ignore
+        let! content = manyCharsTill anyChar (pstring "//]")
         do! ws
         return content }
 
@@ -304,7 +304,7 @@ module private ParseImpl =
         // parse the #define macros to get the macro name
         let define = pipe2 (keyword "define" >>. ident) line
                        (fun id line -> forbiddenNames <- id :: forbiddenNames; "define " + id + line)
-        pchar '#' >>. (define <|> line) .>> ws |>> (fun s -> "#" + s)
+        pchar '#' >>. (define <|> line) .>> ws |>> (fun s -> "#" + s + "\n")
 
     // HLSL attribute, eg. [maxvertexcount(12)]
     let attribute =

--- a/src/printer.fs
+++ b/src/printer.fs
@@ -231,7 +231,7 @@ module private PrinterImpl =
         | Jump(k, Some exp) -> out "%s%s;" (jumpKeywordToString k) (exprToS exp |> sp)
         | Verbatim s ->
             // add a space at end when it seems to be needed
-            let s = if System.Char.IsLetterOrDigit s.[s.Length - 1] then s + " " else s
+            let s = if s.Length > 0 && System.Char.IsLetterOrDigit s.[s.Length - 1] then s + " " else s
             if s <> "" && s.[0] = '#' then out "%s%s" (backslashN()) (escape s)
             else escape s
         | Switch(e, cl) ->
@@ -256,8 +256,8 @@ module private PrinterImpl =
     let topLevelToS = function
         | TLVerbatim s ->
             // add a space at end when it seems to be needed
-            let s = if System.Char.IsLetterOrDigit s.[s.Length - 1] then s + " " else s
-            out "%s%s" (nl 0) (escape s)
+            let trailing = if s.Length > 0 && System.Char.IsLetterOrDigit s.[s.Length - 1] then " " else ""
+            out "%s%s%s" (nl 0) (escape s) trailing
         | Function (fct, Block []) -> out "%s%s%s{}" (nl 0) (funToS fct) (nl 0)
         | Function (fct, (Block _ as body)) -> out "%s%s%s" (nl 0) (funToS fct) (stmtToS 0 body)
         | Function (fct, body) -> out "%s%s%s{%s%s}" (nl 0) (funToS fct) (nl 0) (stmtToS 1 body) (nl 0)

--- a/src/rewriter.fs
+++ b/src/rewriter.fs
@@ -34,26 +34,24 @@ let private stripSpaces str =
     // hack because we can't remove space in "#define foo (1+1)"
 
     let mutable space = false
-    let mutable macro = false
+    let mutable wasNewline = false
     for c in str do
         if c = '\n' then
-            if macro then write '\n'
-            else space <- true
-            macro <- false
+            if not wasNewline then
+                write '\n'
+            space <- false
+            wasNewline <- true
 
         elif Char.IsWhiteSpace(c) then
             space <- true
+            wasNewline <- false
         else
-            if not macro && c = '#' then
-                macro <- true
-                if last <> '\n' then write '\n'
-
+            wasNewline <- false
             if space && isId c && isId last then
                 write ' '
             write c
             space <- false
 
-    if macro then result.Append("\n") |> ignore
     result.ToString()
 
 

--- a/tests/commands.txt
+++ b/tests/commands.txt
@@ -15,6 +15,7 @@
 --no-renaming --format c-array --no-inlining -o tests/unit/float.frag.expected tests/unit/float.frag
 --no-renaming --format indented --no-inlining -o tests/unit/nested_if.frag.expected tests/unit/nested_if.frag
 --format indented -o tests/unit/precision.frag.expected tests/unit/precision.frag
+--format c-array --no-inlining --no-renaming -o tests/unit/verbatim.frag.expected tests/unit/verbatim.frag
 
 # Inlining unit tests
 

--- a/tests/unit/geometry.hlsl.expected
+++ b/tests/unit/geometry.hlsl.expected
@@ -1,11 +1,11 @@
-/* File generated with Shader Minifier 1.3
+/* File generated with 
  * http://www.ctrl-alt-test.fr
  */
 #ifndef GEOMETRY_HLSL_EXPECTED_
 # define GEOMETRY_HLSL_EXPECTED_
 
 const char *geometry_hlsl =
- "[maxvertexcount(3)]"
+ "[maxvertexcount(3)]\n"
  "void GSScene(triangleadj GSSceneIn input[6],inout TriangleStream<PSSceneIn> OutputStream)"
  "{"
    "PSSceneIn output=(PSSceneIn)0;"

--- a/tests/unit/verbatim.frag
+++ b/tests/unit/verbatim.frag
@@ -1,0 +1,33 @@
+//[
+// Test case for https://github.com/laurentlb/Shader_Minifier/issues/168
+//]
+
+//[
+int foo(int x) {
+  return 2;
+}
+//]
+
+int my_function() {
+  int i = 2;
+//[
+foo(1   +   1  )  ;
+//]
+  return i;
+}
+
+int verbatim_with_newlines() {
+//[
+
+
+int        x;
+
+
+
+int     y;
+
+
+
+//]
+  return x + y;
+}

--- a/tests/unit/verbatim.frag.expected
+++ b/tests/unit/verbatim.frag.expected
@@ -1,0 +1,18 @@
+/* File generated with 
+ * http://www.ctrl-alt-test.fr
+ */
+
+// tests/unit/verbatim.frag
+"//Test case for https://github.com/laurentlb/Shader_Minifier/issues/168\n"
+ "int foo(int x){\nreturn 2;\n}\n"
+ "int my_function()"
+ "{"
+   "int i=2;"
+   "foo(1+1);\n"
+   "return i;"
+ "}"
+ "int verbatim_with_newlines()"
+ "{"
+   "int x;\nint y;\n"
+   "return x+y;"
+ "}",


### PR DESCRIPTION
Try to preserve some \n as well (otherwise, the next line would be moved inside the comment)

Fix #168