### PR TITLE
Make LValue detection more precise and more reusable

### DIFF
--- a/tests/unit/inline-aggro.aggro.expected
+++ b/tests/unit/inline-aggro.aggro.expected
@@ -36,9 +36,7 @@ float inl7()
 }
 int inl8(ivec3 x)
 {
-  int i=1;
-  x[i]+=1;
-  return x[i]+i;
+  return x[1]+=1,x[1]+1;
 }
 float noinl1()
 {

--- a/tests/unit/inline.aggro.expected
+++ b/tests/unit/inline.aggro.expected
@@ -1,3 +1,5 @@
+#version 120
+
 float result;
 void main()
 {
@@ -36,6 +38,11 @@ int dont_inline_lvalue()
   int a=1;
   a=2;
   return 3;
+}
+float arr[]=float[](3.4,4.2);
+void lvalues()
+{
+  arr[1]=2.;
 }
 uniform int time;
 in int sync;

--- a/tests/unit/inline.expected
+++ b/tests/unit/inline.expected
@@ -1,3 +1,5 @@
+#version 120
+
 float result;
 void main()
 {
@@ -38,6 +40,11 @@ int dont_inline_lvalue()
   int a=1;
   a=2;
   return 3;
+}
+float arr[]=float[](3.4,4.2);
+void lvalues()
+{
+  arr[1]=2.;
 }
 uniform int time;
 in int sync;

--- a/tests/unit/inline.frag
+++ b/tests/unit/inline.frag
@@ -1,3 +1,5 @@
+#version 120
+
 float result;
 
 void main()
@@ -65,6 +67,12 @@ int dont_inline_lvalue() {
   int a = 1;
   a = 2;
   return 3;
+}
+
+float arr[] = float[](3.4, 4.2);
+void lvalues() {
+  int a = 1;
+  arr[a] = 2.;
 }
 
 uniform int time;

--- a/tests/unit/inline.no.expected
+++ b/tests/unit/inline.no.expected
@@ -1,3 +1,5 @@
+#version 120
+
 float result;
 void main()
 {
@@ -42,6 +44,12 @@ int dont_inline_lvalue()
   int a=1;
   a=2;
   return 3;
+}
+float arr[]=float[](3.4,4.2);
+void lvalues()
+{
+  int a=1;
+  arr[a]=2.;
 }
 uniform int time;
 in int sync;


### PR DESCRIPTION
- In `arr[idx] = 1`, we now detect that arr a lvalue, while idx is not.
- LValue detection is now part of the generic map function