### PR TITLE
Optimize conditional expressions

### DIFF
--- a/tests/commands.txt
+++ b/tests/commands.txt
@@ -17,6 +17,7 @@
 --format indented -o tests/unit/precision.frag.expected tests/unit/precision.frag
 --no-remove-unused --format c-array --no-inlining --no-renaming -o tests/unit/verbatim.frag.expected tests/unit/verbatim.frag
 --no-remove-unused --format indented --no-renaming -o tests/unit/forward_declaration.frag.expected tests/unit/forward_declaration.frag
+--no-remove-unused --format indented --no-renaming -o tests/unit/conditionals.frag.expected tests/unit/conditionals.frag
 
 # Inlining unit tests
 

--- a/tests/unit/conditionals.frag
+++ b/tests/unit/conditionals.frag
@@ -1,0 +1,38 @@
+bool success() { return true; }
+bool fail() { return false; }
+
+// After optimization, no call to fail should remain.
+
+bool ternary() {
+  return 1 < 2 ? success() : fail();
+}
+
+bool ternary2() {
+  return 2 < 1 ? fail() : success();
+}
+
+bool or() {
+  return true || fail();
+}
+
+bool or2() {
+  return false || success();
+}
+
+bool or3() {
+  return success() || false;
+}
+
+bool and() {
+  int a = -2;
+  return a && success();
+}
+
+bool and2() {
+  int a = 0;
+  return a && fail();
+}
+
+bool and3() {
+  return success() && true;
+}

--- a/tests/unit/conditionals.frag.expected
+++ b/tests/unit/conditionals.frag.expected
@@ -1,0 +1,40 @@
+bool success()
+{
+  return true;
+}
+bool fail()
+{
+  return false;
+}
+bool ternary()
+{
+  return success();
+}
+bool ternary2()
+{
+  return success();
+}
+bool or()
+{
+  return true;
+}
+bool or2()
+{
+  return success();
+}
+bool or3()
+{
+  return success();
+}
+bool and()
+{
+  return success();
+}
+bool and2()
+{
+  return false;
+}
+bool and3()
+{
+  return success();
+}


### PR DESCRIPTION
Optimize &&, || and the ?: ternary operator when a bool operand is statically known.