### PR TITLE
Rename and use enum instead of string for the export prefix

### DIFF
--- a/src/ast.fs
+++ b/src/ast.fs
@@ -110,12 +110,15 @@ let makeFunctionType ty name args sem =
 
 // An ExportedName is a name that is used outside of the shader code (e.g. uniform and attribute
 // values). We need to provide accessors for the developer (e.g. create macros for C/C++).
+type ExportPrefix =
+    | Variable
+    | HlslFunction
 type ExportedName = {
-    ty: string  // "F" for hlsl functions, empty for vars
+    prefix: ExportPrefix
     name: string
     newName: string
 }
-       
+
 type Shader = {
     filename: string
     mutable code: TopLevel list

--- a/src/formatter.fs
+++ b/src/formatter.fs
@@ -4,8 +4,8 @@ open System
 open System.IO
 open Options.Globals
 
-let private formatPrefix forceUppercase = function
-    | Ast.ExportPrefix.Variable -> if forceUppercase then "VAR" else "var"
+let private formatPrefix = function
+    | Ast.ExportPrefix.Variable -> "var"
     | Ast.ExportPrefix.HlslFunction -> "F"
 
 let private printHeader out (shaders: Ast.Shader[]) asAList exportedNames =
@@ -22,7 +22,7 @@ let private printHeader out (shaders: Ast.Shader[]) asAList exportedNames =
 
     for value: Ast.ExportedName in List.sort exportedNames do
         // let newName = Printer.identTable.[int newName]
-        fprintfn out "# define %s_%s \"%s\"" (formatPrefix true value.prefix) value.name value.newName
+        fprintfn out "# define %s_%s \"%s\"" ((formatPrefix value.prefix).ToUpper()) value.name value.newName
 
     fprintfn out ""
     for shader in shaders do
@@ -52,7 +52,7 @@ let private printJSHeader out (shaders: Ast.Shader[]) exportedNames =
     fprintfn out "// Generated with Shader Minifier %s (https://github.com/laurentlb/Shader_Minifier/)" Options.version
 
     for value: Ast.ExportedName in List.sort exportedNames do
-        fprintfn out "var %s_%s = \"%s\"" (formatPrefix false value.prefix) (value.name.ToUpper()) value.newName
+        fprintfn out "var %s_%s = \"%s\"" (formatPrefix value.prefix) (value.name.ToUpper()) value.newName
 
     fprintfn out ""
     for shader in shaders do
@@ -64,7 +64,7 @@ let private printNasmHeader out (shaders: Ast.Shader[]) exportedNames =
     fprintfn out "; Generated with Shader Minifier %s (https://github.com/laurentlb/Shader_Minifier/)" Options.version
 
     for value: Ast.ExportedName in List.sort exportedNames do
-        fprintfn out "_%s_%s: db '%s', 0" (formatPrefix false value.prefix) (value.name.ToUpper()) value.newName
+        fprintfn out "_%s_%s: db '%s', 0" (formatPrefix value.prefix) (value.name.ToUpper()) value.newName
 
     fprintfn out ""
     for shader in shaders do
@@ -76,7 +76,7 @@ let private printRustHeader out (shaders: Ast.Shader[]) exportedNames =
     fprintfn out "// Generated with Shader Minifier %s (https://github.com/laurentlb/Shader_Minifier/)" Options.version
 
     for value: Ast.ExportedName in List.sort exportedNames do
-        fprintfn out "pub const %s_%s: &'static [u8] = b\"%s\\0\";" (formatPrefix true value.prefix) (value.name.ToUpper()) value.newName
+        fprintfn out "pub const %s_%s: &'static [u8] = b\"%s\\0\";" ((formatPrefix value.prefix).ToUpper()) (value.name.ToUpper()) value.newName
 
     for shader in shaders do
         fprintfn out ""

--- a/src/formatter.fs
+++ b/src/formatter.fs
@@ -4,6 +4,10 @@ open System
 open System.IO
 open Options.Globals
 
+let private formatPrefix forceUppercase = function
+    | Ast.ExportPrefix.Variable -> if forceUppercase then "VAR" else "var"
+    | Ast.ExportPrefix.HlslFunction -> "F"
+
 let private printHeader out (shaders: Ast.Shader[]) asAList exportedNames =
     let fileName =
         if options.outputName = "" || options.outputName = "-" then "shader_code.h"
@@ -18,10 +22,7 @@ let private printHeader out (shaders: Ast.Shader[]) asAList exportedNames =
 
     for value: Ast.ExportedName in List.sort exportedNames do
         // let newName = Printer.identTable.[int newName]
-        if value.ty = "" then
-            fprintfn out "# define VAR_%s \"%s\"" value.name value.newName
-        else
-            fprintfn out "# define %s_%s \"%s\"" value.ty value.name value.newName
+        fprintfn out "# define %s_%s \"%s\"" (formatPrefix true value.prefix) value.name value.newName
 
     fprintfn out ""
     for shader in shaders do
@@ -51,10 +52,7 @@ let private printJSHeader out (shaders: Ast.Shader[]) exportedNames =
     fprintfn out "// Generated with Shader Minifier %s (https://github.com/laurentlb/Shader_Minifier/)" Options.version
 
     for value: Ast.ExportedName in List.sort exportedNames do
-        if value.ty = "" then
-            fprintfn out "var var_%s = \"%s\"" (value.name.ToUpper()) value.newName
-        else
-            fprintfn out "var %s_%s = \"%s\"" value.ty (value.name.ToUpper()) value.newName
+        fprintfn out "var %s_%s = \"%s\"" (formatPrefix false value.prefix) (value.name.ToUpper()) value.newName
 
     fprintfn out ""
     for shader in shaders do
@@ -66,10 +64,7 @@ let private printNasmHeader out (shaders: Ast.Shader[]) exportedNames =
     fprintfn out "; Generated with Shader Minifier %s (https://github.com/laurentlb/Shader_Minifier/)" Options.version
 
     for value: Ast.ExportedName in List.sort exportedNames do
-        if value.ty = "" then
-            fprintfn out "_var_%s: db '%s', 0" (value.name.ToUpper()) value.newName
-        else
-            fprintfn out "_%s_%s: db '%s', 0" value.ty (value.name.ToUpper()) value.newName
+        fprintfn out "_%s_%s: db '%s', 0" (formatPrefix false value.prefix) (value.name.ToUpper()) value.newName
 
     fprintfn out ""
     for shader in shaders do
@@ -81,10 +76,7 @@ let private printRustHeader out (shaders: Ast.Shader[]) exportedNames =
     fprintfn out "// Generated with Shader Minifier %s (https://github.com/laurentlb/Shader_Minifier/)" Options.version
 
     for value: Ast.ExportedName in List.sort exportedNames do
-        if value.ty = "" then
-            fprintfn out "pub const VAR_%s: &'static [u8] = b\"%s\\0\";" (value.name.ToUpper()) value.newName
-        else
-            fprintfn out "pub const %s_%s: &'static [u8] = b\"%s\\0\":" value.ty (value.name.ToUpper()) value.newName
+        fprintfn out "pub const %s_%s: &'static [u8] = b\"%s\\0\";" (formatPrefix true value.prefix) (value.name.ToUpper()) value.newName
 
     for shader in shaders do
         fprintfn out ""

--- a/src/renamer.fs
+++ b/src/renamer.fs
@@ -181,9 +181,9 @@ module private RenamerImpl =
         for name in names do env <- dontRename env (Ident name)
         env
 
-    let export env ty (id: Ident) =
+    let export env prefix (id: Ident) =
         if not id.IsUniqueId then
-            env.exportedNames.Value <- {ty = ty; name = id.OldName; newName = id.Name} :: env.exportedNames.Value
+            env.exportedNames.Value <- {prefix = prefix; name = id.OldName; newName = id.Name} :: env.exportedNames.Value
 
     let renFunction env nbArgs (id: Ident) =
         // we're looking for a function name, already used before,
@@ -220,7 +220,7 @@ module private RenamerImpl =
                 env
             | None ->
                 let newEnv = renFunction env (List.length f.args) f.fName
-                if isExternal then export env "F" f.fName
+                if isExternal then export env ExportPrefix.HlslFunction f.fName
                 newEnv
 
     let renList env fct li =
@@ -261,7 +261,7 @@ module private RenamerImpl =
                     env
                 | None ->
                     let env = env.newName env decl.name
-                    export env "" decl.name
+                    export env ExportPrefix.Variable decl.name
                     env
 
         renList env aux vars


### PR DESCRIPTION
This also fixes formatting of hlsl function externals in rust. Tests are lacking