### PR TITLE
Apply vector simplification only when the number of arguments matches

### DIFF
--- a/src/rewriter.fs
+++ b/src/rewriter.fs
@@ -189,7 +189,9 @@ let private simplifyOperator env = function
 
 
 // Simplify calls to the vec constructor.
-let private simplifyVec constr args =
+let private simplifyVec (constr: Ident) args =
+    let vecSize = try int(constr.Name.[constr.Name.Length - 1]) - int '0' with _ -> 0
+
     // Combine swizzles, e.g.
     //    vec4(v1.x, v1.z, v2.r, v2.t)  =>  vec4(v1.xz, v2.xy)
     let rec combineSwizzles = function
@@ -229,7 +231,7 @@ let private simplifyVec constr args =
         | _ -> allArgs
 
     let args = combineSwizzles args |> List.map useInts
-    let args = mergeAllEquals args args
+    let args = if args.Length = vecSize then mergeAllEquals args args else args
     FunCall (Var constr, args)
 
 let private simplifyExpr (didInline: bool ref) env = function

--- a/tests/unit/vectors.frag
+++ b/tests/unit/vectors.frag
@@ -12,8 +12,11 @@ vec4 constructor() {
 	return vec4(1., 1e2, 2e3, 3e4);
 }
 
-vec2 constructor2() {
-	return vec2(1e10, 1e10);
+float constructors() {
+    vec2 v2 = vec2(1e10, 1e10);
+    vec3 v3 = vec3(v2, v2);
+    vec4 v4 = vec4(v3, v2);
+    return v2.x + v3.x + v4.x;
 }
 
-void main() { swizzles(); constructor(); constructor2(); }
+void main() { swizzles(); constructor(); constructors(); }

--- a/tests/unit/vectors.frag.expected
+++ b/tests/unit/vectors.frag.expected
@@ -9,13 +9,16 @@ vec4 constructor()
 {
   return vec4(1,100,2e3,3e4);
 }
-vec2 constructor2()
+float constructors()
 {
-  return vec2(1e10);
+  vec2 v2=vec2(1e10);
+  vec3 v3=vec3(v2,v2);
+  vec4 v4=vec4(v3,v2);
+  return v2.x+v3.x+v4.x;
 }
 void main()
 {
   swizzles();
   constructor();
-  constructor2();
+  constructors();
 }


### PR DESCRIPTION
vec3(x,x,x) => vec3(x)
vec4(v2,v2) => vec4(v2,v2)

Fixes #249 