### PR TITLE
Fix potential unsafe swizzle optimizations

### DIFF
--- a/tests/unit/vectors.frag
+++ b/tests/unit/vectors.frag
@@ -23,7 +23,16 @@ float withExtraComponents() {
     vec2 v2 = vec2(1);
     vec3 v3 = vec3(1, 2, v2.x);
     vec4 v4 = vec4(v2, v3.xy);
-    return v2.x + v3.x + v4.x;
+    vec3 v5 = vec3(1, v3.rg);
+    return v2.x + v3.x + v4.x + v5.x;
+}
+
+float withExtraComponentsUnsafe(in vec3 a) {
+    vec3 v1 = vec3(a.x);
+    vec3 v2 = vec3(1.0, a.x);
+    vec2 v3 = vec3(1.0, a.y);
+    vec3 v4 = vec3(1.0, 2.0, a.y);
+    return v1.x + v2.x + v3.x + v4.x;
 }
 
 struct S{

--- a/tests/unit/vectors.frag.expected
+++ b/tests/unit/vectors.frag.expected
@@ -21,7 +21,15 @@ float withExtraComponents()
   vec2 v2=vec2(1);
   vec3 v3=vec3(1,2,v2);
   vec4 v4=vec4(v2,v3);
-  return v2.x+v3.x+v4.x;
+  vec3 v5=vec3(1,v3);
+  return v2.x+v3.x+v4.x+v5.x;
+}
+float withExtraComponentsUnsafe(vec3 a)
+{
+  vec3 v1=vec3(a.x),v2=vec3(1,a.x);
+  vec2 v3=vec3(1,a.y);
+  vec3 v4=vec3(1,2,a.y);
+  return v1.x+v2.x+v3.x+v4.x;
 }struct S{vec2 p1;vec2 cp1;vec2 cp2;vec2 p2;};
 vec2 calc(S points,float t)
 {


### PR DESCRIPTION
The optimization in #253 is unsafe -- `vec3(a.x)` and `vec3(x)` are not equivalent. For a single-element swizzles, they are only sure to be safe if they are the Nth argument to a vecN constructor. This change counts the number of arguments, and only allows a single-element swizzle to be optimized in that case.

This does miss some edge cases -- for example, I think the swizzle in code like `vec3(foo.xy, bar.x)` is safe to remove (`vec3(foo.xy, bar)`) but that doesn't seem to actually happen in any of the examples in this repo, and it's super tricky to get right in practise (if `foo.xy` is some variable instead of a swizzle right there), etc etc. So there is potentially still something on the table, but at least for the cases available this is good enough for now.

Fixes #297