### PR TITLE
Fix mutated idents in functions which are inlined more than once

### DIFF
--- a/src/rewriter.fs
+++ b/src/rewriter.fs
@@ -69,10 +69,15 @@ let private inlineFn (declArgs:Decl list) passedArgs bodyExpr =
         let declElt = List.exactlyOne (snd declArg)
         argMap <- argMap.Add(declElt.name.Name, passedArg)
     let mapInline _ = function
-        | Var iv as ie ->
+        | Var iv ->
             match argMap.TryFind iv.Name with
             | Some inlinedExpr -> inlinedExpr
-            | _ -> ie
+            // This var isn't an argument to the inlined function (must be a
+            // global or similar). We need to create a brand-new ident.  This is
+            // because the renamer does its work via mutation on the ident. So
+            // if this function gets inlined in more than one place, we don't
+            // mutations to affect all of the inlined idents.
+            | None -> Var (Ident (iv.Name))
         | ie -> ie
     mapExpr (mapEnv mapInline id) bodyExpr
 

--- a/tests/commands.txt
+++ b/tests/commands.txt
@@ -43,6 +43,7 @@
 --no-remove-unused --no-renaming --format indented --aggressive-inlining -o tests/unit/inline-aggro.aggro.expected tests/unit/inline-aggro.frag
 --no-remove-unused --no-renaming --format indented -o tests/unit/inline-fn.expected tests/unit/inline-fn.frag
 --no-remove-unused --no-renaming --format indented --aggressive-inlining -o tests/unit/inline-fn.aggro.expected tests/unit/inline-fn.frag
+--no-remove-unused --format indented -o tests/unit/inline-fn-multiple.expected tests/unit/inline-fn-multiple.frag
 --no-remove-unused --no-renaming --format indented -o tests/unit/simplify.expected tests/unit/simplify.frag
 
 # Partial renaming tests

--- a/tests/unit/inline-fn-multiple.expected
+++ b/tests/unit/inline-fn-multiple.expected
@@ -1,0 +1,9 @@
+uniform vec3 v[42];
+vec3 N()
+{
+  return v[4];
+}
+vec3 N(float N)
+{
+  return v[4]+N;
+}

--- a/tests/unit/inline-fn-multiple.frag
+++ b/tests/unit/inline-fn-multiple.frag
@@ -1,0 +1,13 @@
+uniform vec3 params[42];
+
+vec3 i_getFoo() {
+  return params[4];
+}
+
+vec3 f1() {
+  return i_getFoo();
+}
+
+vec3 f2(float a) {
+  return i_getFoo() + a;
+}


### PR DESCRIPTION
The function inlining directly drops the inlined function's body into the place it gets inlined. This is problematic for mutable Idents -- in particular, the renamer could do some very strange things as it tried to rename the same Ident to more than one thing. For example, the included test case was previously renamed to the following:

```
uniform vec3 v[42];
vec3 N()
{
  return v[4];
}
vec3 N(float v)
{
  return v[4]+v; // <-- Whoops, used "v" for both the global and the local!
}
```

Therefore all Idents (which aren't function parameters that get substituted away) need to get copied during inlining.