### PR TITLE
Changed exit-code of `--version` to 0

### DIFF
--- a/Minifier/options.fs
+++ b/Minifier/options.fs
@@ -146,7 +146,7 @@ let initFiles argv =
     let options, filenames = initPrivate argv
     if options.version then
         printfn "%s" helpTextMessage
-        System.Environment.Exit(0)
-    if filenames.Length = 0 then
-        failwith (argParser.Value.PrintUsage(message = "Missing parameter: the list of shaders to minify"))
+    else
+        if filenames.Length = 0 then
+            failwith (argParser.Value.PrintUsage(message = "Missing parameter: the list of shaders to minify"))
     options, filenames

--- a/ShaderMinifier/main.fs
+++ b/ShaderMinifier/main.fs
@@ -40,7 +40,10 @@ let main argv =
             let options, files = Options.initFiles argv
             if options.verbose then
                 printfn "Shader Minifier %s - https://github.com/laurentlb/Shader_Minifier" Options.version
-            run options files
+            if options.version then
+                0
+            else
+                run options files
         with
         | :? Argu.ArguParseException as ex ->
             printfn "%s" ex.Message


### PR DESCRIPTION
Hey! I just noticed running `shader_minifier.exe --version` has a nonzero (error) exit code and thought I'd fix it quickly.